### PR TITLE
fix: bump version (VF-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@voiceflow/body-parser",
   "description": "Node.js body parsing middleware",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

`@voiceflow/body-parser@1.21.1` is now up to date with `body-parser@1.19.1`

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written